### PR TITLE
fixed exception on no results

### DIFF
--- a/webharness/harness.js
+++ b/webharness/harness.js
@@ -150,7 +150,7 @@ function run_next_test() {
   }
   current_window.addEventListener("error", harness_error);
   current_window.addEventListener("load", function() {
-    dump("loaded\n");
+    dump("loaded " + path + "\n");
     send_message({"action": "test_loaded", "test": path});
     // Wait for other side to have loaded this test.
     wait_for_message().then(function (m) {


### PR DESCRIPTION
This should fix the exception we get when the remote command died without any output like this:

Traceback (most recent call last):
  File "/home/mozilla/src/steeplechase/steeplechase/runsteeplechase.py", line 308, in <module>
    sys.exit(0 if main(sys.argv[1:]) else 1)
  File "/home/mozilla/src/steeplechase/steeplechase/runsteeplechase.py", line 298, in main
    html_pass_count, html_fail_count = test.run()
  File "/home/mozilla/src/steeplechase/steeplechase/runsteeplechase.py", line 187, in run
    passes, failures = result
TypeError: 'NoneType' object is not iterable
