### PR TITLE
Add mozdevice>=0.40 to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ dependencies = ['mozhttpd',
                 'mozprofile',
                 'mozprocess',
                 'mozrunner',
+                'mozdevice>=0.40',
                ]
 
 setup(name='steeplechase',


### PR DESCRIPTION
Add mozdevice>=0.40 to requirements so that this works with Windows clients

due to Bug 1023670.
