### PR TITLE
Bug 1075636 - steeplechase hangs if one of the clients crashes

### DIFF
--- a/steeplechase/runsteeplechase.py
+++ b/steeplechase/runsteeplechase.py
@@ -191,14 +191,14 @@ class Dmg(Package):
         try:
             output = self.dm.shellCheckOutput(umount_cmd, env=None)
         except Exception as ex:
-            self.log.info("EXPECTED: umount failed with %s" % ex)
+            self.log.debug("EXPECTED: umount failed with %s" % ex)
         cmd = ['hdiutil', 'attach', '-quiet', '-mountpoint', '/Volumes/Steeplechase', self.remote_archive_name()]
-        self.log.info("Running %s on remote host.." % cmd)
+        self.log.debug("Running %s on remote host.." % cmd)
         output = self.dm.shellCheckOutput(cmd, env=None)
         cmd = ['cp', '-r', '/Volumes/Steeplechase/*.app', os.path.join(self.remote_path, 'firefox.app')]
-        self.log.info("Running %s on remote host.." % cmd)
+        self.log.debug("Running %s on remote host.." % cmd)
         output = self.dm.shellCheckOutput(cmd, env=None)
-        self.log.info("Running %s on remote host.." % umount_cmd)
+        self.log.debug("Running %s on remote host.." % umount_cmd)
         output = self.dm.shellCheckOutput(umount_cmd, env=None)
 
     def path_to_launch(self):


### PR DESCRIPTION
```
Per suggestion by ted: add exception handler when running shell
script.
```
