### PR TITLE
catch test errors via window.onerror to get all errors

### DIFF
--- a/webharness/harness.js
+++ b/webharness/harness.js
@@ -134,6 +134,11 @@ function run_tests(results) {
   run_next_test();
 }
 
+function test_error(errorMsg, url, lineNumber) {
+  log_result(false, errorMsg + " @" + url + ":" + lineNumber, tests[current_test].path);
+  finish();
+}
+
 function run_next_test() {
   ++current_test;
   if (current_test >= tests.length) {
@@ -148,7 +153,7 @@ function run_next_test() {
     harness_error(ex);
     return;
   }
-  current_window.addEventListener("error", harness_error);
+  current_window.onerror = test_error;
   current_window.addEventListener("load", function() {
     dump("loaded " + path + "\n");
     send_message({"action": "test_loaded", "test": path});
@@ -170,7 +175,7 @@ function run_next_test() {
 }
 
 function harness_error(error) {
-  log_result(false, error.message, "harness");
+  log_result(false, error.message, "harness.js");
   var stack = error.stack || error.error || new Error().stack;
   dump(stack +"\n");
   finish();


### PR DESCRIPTION
The existing error event handler unfortunately does not catch all errors happening in WebRTC tests, as callbacks in PeerConnection.js catch errors and deliver them only to window.onerror. This patch catches all errors in executed tests.