### PR TITLE
enabled fake AV streams from the user prefs

### DIFF
--- a/steeplechase/runsteeplechase.py
+++ b/steeplechase/runsteeplechase.py
@@ -286,6 +286,7 @@ class HTMLTests(object):
         prefs["steeplechase.signalling_server"] = self.options.signalling_server
         prefs["steeplechase.signalling_room"] = str(uuid.uuid4())
         prefs["media.navigator.permission.disabled"] = True
+        prefs["media.navigator.streams.fake"] = True
 
         specialpowers_path = self.options.specialpowers
         threads = []


### PR DESCRIPTION
Fake AV streams no longer get enabled through the JS functions in mochitest which get run as part of the test if it runs under steeplechase.
This re-enables the fake AV streams as default under steeplechase, and can still be dis-abled via the 'fake' constraint from the test itself.