### PR TITLE
Enable console logging

### DIFF
--- a/webharness/harness.js
+++ b/webharness/harness.js
@@ -195,6 +195,7 @@ function finish() {
 
 function log(message, test, extra) {
   //TODO: make this structured?
+  console.log(message);
   dump(message + "\n");
 }
 

--- a/webharness/harness.js
+++ b/webharness/harness.js
@@ -204,5 +204,6 @@ function log_result(result, message, test) {
                 'message': message,
                 'time': Date.now(),
                 'source_file': test || tests[current_test].path};
+  console.log(JSON.stringify(output));
   dump(JSON.stringify(output) + "\n");
 }


### PR DESCRIPTION
If Fx is hanging during steeplechase runs, steeplechase gives up and terminates the connection to Negatus. But even if you can get to Fx on the client machine you can't debug the problem, because the stdout of the Fx is redirected into Negatus.
This should hopefully allow us to debug the problems more easily by sending the log message to stdout and the console log.